### PR TITLE
Check saved system time at startup.

### DIFF
--- a/languages/MicroCoinWallet.hu.po
+++ b/languages/MicroCoinWallet.hu.po
@@ -1734,6 +1734,9 @@ msgstr ""
 msgid "%s Last connection: %s"
 msgstr "%s Utolsó kapcsolat: %s"
 
+#: ufrmwallet.rslastdateerror
+msgid "Your system time is invalid, please verify!"
+msgstr ""
 #: ufrmwallet.rslastdssecdss
 msgid "Last %d: %s sec. - %d: %s sec. - %d: %s sec. - %d: %s sec. - %d: %s sec."
 msgstr "Utolsó %d: %s mp. - %d: %s mp. - %d: %s mp. - %d: %s mp. - %d: %s mp."

--- a/languages/MicroCoinWallet.po
+++ b/languages/MicroCoinWallet.po
@@ -1706,6 +1706,10 @@ msgstr ""
 msgid "%s Last connection: %s"
 msgstr ""
 
+#: ufrmwallet.rslastdateerror
+msgid "Your system time is invalid, please verify!"
+msgstr ""
+
 #: ufrmwallet.rslastdssecdss
 msgid "Last %d: %s sec. - %d: %s sec. - %d: %s sec. - %d: %s sec. - %d: %s sec."
 msgstr ""


### PR DESCRIPTION
Help detecting invalid system time.
New file generated with name Wallet.date, this contains last system time.
When last saved time higher than current system time at startup, warning window popup.
When Wallet.date removed from directory, new valid date file generated.
Date file updated, when user entering or leaving application with valid date. 